### PR TITLE
XSLT generate-id is not always a 7-digit number

### DIFF
--- a/normalize_update_rdf.rb
+++ b/normalize_update_rdf.rb
@@ -62,11 +62,11 @@ def parse_nt(ntriples_dump)
 
   ntriples_dump.split("\n").each do |line|
     s = StringScanner.new(line)
-    subj = s.scan(/_:id\d{7}|<[^>]+>/).gsub(/^<|>$/, '')
+    subj = s.scan(/_:id\d+|<[^>]+>/).gsub(/^<|>$/, '')
     s.skip(/\s+/)
     pred = s.scan(/<[^>]+>/).gsub(/^<|>$/, '')
     s.skip(/\s+/)
-    obj = s.scan(/_:id\d{7}|"[^"]*"|<[^>]+>/).gsub(/^<|>$/, '').gsub(/^"|"$/, '')
+    obj = s.scan(/_:id\d+|"[^"]*"|<[^>]+>/).gsub(/^<|>$/, '').gsub(/^"|"$/, '')
 
     triples[subj] ||= []
     triples[subj] << [subj, pred, obj]


### PR DESCRIPTION
The xslt "preprocessor" uses generate-id, which is then interpreted by normalize_update_rdf.rb.
Later, however assumes, that such generated ids are always 7-digit numbers, which is not true on my Debian lenny box. The serialization will hence fail then.

Fix it by recognizing any number of digits.
